### PR TITLE
SRE-0000 - update docker to use workload identity federation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,19 @@ The current documentation assumes that the latest version is `v6`
 The following examples assume that you have included a github-actions repo checkout in the previous step.
 
 ## docker-build-push
-Build docker image and publish
+Build docker image and publish to GCR using [Workload Identity Federation](https://cloud.google.com/iam/docs/configuring-workload-identity-federation#github-actions).
+This action needs [Workload Identity Federation Setup for Github Actions](https://cloud.google.com/blog/products/identity-security/enabling-keyless-authentication-from-github-actions) and 
+Service Account created with permission to Push container images to GCR.
+
+For `tags` you can also use https://github.com/marketplace/actions/docker-metadata-action
 
 ```yaml
 - name: Docker build and push
-  uses: e-conomic/github-actions/docker-build-push@v6
+  uses: e-conomic/github-actions/docker-build-push@v7
   with:
-    password: ${{ secrets.DEVECONOCM_GCR_RW }}
-    tags: eu.gcr.io/dev-econo-cm/<project-name-and-version>
+    tags: eu.gcr.io/dev-econo-cm/<service-name-and-version>
+    workload_identity_pool_provider: <workload-identity-pool-provider>
+    gcr_service_account_email: <google-service-account-email>
 ```
 ### User customizable options
 * `context` (optional, default value '.') - Folder containing Dockerfile. Context parameter for docker/build-push-action action

--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ Service Account created with permission to Push container images to GCR.
 
 For `tags` you can also use https://github.com/marketplace/actions/docker-metadata-action
 
+### Pre-requisite:
+These job level permissions are required by workload identity federation as decribed here:
+https://github.com/google-github-actions/auth#authenticating-via-workload-identity-federation-1
+
+```
+permissions:
+  contents: 'read'
+  id-token: 'write'
+```
+
+### Step:
 ```yaml
 - name: Docker build and push
   uses: e-conomic/github-actions/docker-build-push@v7

--- a/docker-build-push/action.yml
+++ b/docker-build-push/action.yml
@@ -27,8 +27,7 @@ runs:
   using: 'composite'
   steps:
       # Login to GCR: https://github.com/marketplace/actions/authenticate-to-google-cloud
-    - id: 'auth'
-      name: 'Authenticate to Google Cloud'
+    - name: 'Authenticate to Google Cloud'
       uses: 'google-github-actions/auth@v0'
       with:
         workload_identity_provider: ${{ inputs.workload_identity_pool_provider }}

--- a/docker-build-push/action.yml
+++ b/docker-build-push/action.yml
@@ -1,17 +1,16 @@
 name: Docker build and push
-description: Build and push docker image to container registry
+description: Build and push docker image
 
 inputs:
   registry:
     description: "Registry name"
     required: true
     default: "eu.gcr.io"
-  username:
-    description: "Registry username"
+  workload_identity_pool_provider:
+    description: "ID of workload identity federation pool provider"
     required: true
-    default: "_json_key"
-  password:
-    description: "Registry password"
+  gcr_service_account_email:
+    description: "Google Service Account Email with GCR read and write permissions"
     required: true
   tags:
     description: "List of tags"
@@ -27,12 +26,19 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Login to google container repo
-      uses: docker/login-action@v1 
+      # Login to GCR: https://github.com/marketplace/actions/authenticate-to-google-cloud
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v0'
       with:
-        registry: ${{ inputs.registry }}
-        username: ${{ inputs.username }}
-        password: ${{ inputs.password }}
+        workload_identity_provider: ${{ inputs.workload_identity_pool_provider }}
+        service_account: ${{ inputs.gcr_service_account_email }}
+
+      # Configure docker to use the gcloud command-line tool as a credential helper
+      # This avoids using docker/login-action as a middle man.
+    - name: Configure Docker with GCloud credentials
+      shell: bash
+      run: gcloud auth configure-docker
 
     - name: Tag and publish
       uses: docker/build-push-action@v2


### PR DESCRIPTION
Since we have now enabled Workload Identity Federation for Github Actions to Push container images to GCR,
This PR updates the workflow action to utilize it.

## Changelog:
### Change
- update `docker-build-push` action to use `workload identity federation`
- update `README.md` with changes and links for current and future implementations 



