### PR TITLE
Add custom docs directory support

### DIFF
--- a/upload-docs/action.yml
+++ b/upload-docs/action.yml
@@ -5,6 +5,9 @@ inputs:
   docs_bucket_sa:
     description: "Documentation bucket service account"
     required: true
+  docs_directory_name:
+    description: "Directory name where docs are located. If ommited, README.md from the root folder will be uploaded to docs"
+    required: false
 
 runs:
   using: "composite"
@@ -18,16 +21,28 @@ runs:
 
     - name: Upload docs
       shell: bash
+      env:
+        docs_directory_name: ${{ inputs.docs_bucket_sa }}
       run: |
-        echo Creating a temporary directory for docs content
-        mkdir -p _docs
-        echo Searching for readme.md file and coping to temporary directory
-        find -iname readme.md -exec cp {} ./_docs \;
-        echo Listing docs directory content
-        ls -al ./_docs
-        echo Removing existing docs for ${{ github.event.repository.name }}
+        if [ -z "$docs_directory_name" ]
+        then
+          upload_dir=./_docs
+
+          echo "Creating a temporary directory for docs content: $docs_directory_name"
+          mkdir -p _docs
+
+          echo "Searching for readme.md file and coping to temporary directory"
+          find -maxdepth 1 -iname readme.md -exec cp {} ./_docs \;
+        else
+          echo "Using requested docs directory: $docs_directory_name"
+          upload_dir=$docs_directory_name
+        fi
+
+        echo "Listing docs directory content"
+        ls -al $upload_dir
+
+        echo "Removing existing docs for ${{ github.event.repository.name }}"
         gsutil -m rm -r gs://prod-econo-cm_docs/${{ github.event.repository.name }} 2> /dev/null || true
-        echo Uploading docs to Google Cloud Storage for ${{ github.event.repository.name }}
-        gsutil -m cp -r _docs gs://prod-econo-cm_docs/${{ github.event.repository.name }}
-        echo Removing temporary docs directory
-        rm -rf _docs
+
+        echo "Uploading docs to Google Cloud Storage for ${{ github.event.repository.name }}"
+        gsutil -m cp -r $upload_dir gs://prod-econo-cm_docs/${{ github.event.repository.name }}

--- a/upload-docs/action.yml
+++ b/upload-docs/action.yml
@@ -5,9 +5,6 @@ inputs:
   docs_bucket_sa:
     description: "Documentation bucket service account"
     required: true
-  docs_directory_name:
-    description: "Directory name where docs are located. If ommited, README.md from the root folder will be uploaded to docs"
-    required: false
 
 runs:
   using: "composite"
@@ -21,28 +18,23 @@ runs:
 
     - name: Upload docs
       shell: bash
-      env:
-        DOCS_DIR: ${{ inputs.docs_directory_name }}
       run: |
-        if [ -z "$DOCS_DIR" ]
+        mkdir -p ./_docs-prepare
+
+        echo "Copying README.md file from the root directory"
+        find -maxdepth 1 -iname readme.md -exec cp {} ./_docs-prepare \;
+
+        if [[ -d ./docs ]]
         then
-          upload_dir=./_docs
-
-          echo "Creating a temporary directory for docs content: $DOCS_DIR"
-          mkdir -p _docs
-
-          echo "Searching for readme.md file and coping to temporary directory"
-          find -maxdepth 1 -iname readme.md -exec cp {} ./_docs \;
-        else
-          echo "Using requested docs directory: $DOCS_DIR"
-          upload_dir=$DOCS_DIR
+            echo "'docs' directory exists, prepearing for upload"
+            cp -R ./docs ./_docs-prepare/
         fi
 
-        echo "Listing docs directory content"
-        ls -al $upload_dir
+        echo "Listing docs prepared directory structure"
+        ls -alR ./_docs-prepare
 
         echo "Removing existing docs for ${{ github.event.repository.name }}"
-        gsutil -m rm -r gs://prod-econo-cm_docs/${{ github.event.repository.name }} 2> /dev/null || true
+        gsutil -m rm -r gs://prod-econo-cm_docs/${{ github.event.repository.name }} 2>&1 || true
 
         echo "Uploading docs to Google Cloud Storage for ${{ github.event.repository.name }}"
-        gsutil -m cp -r $upload_dir gs://prod-econo-cm_docs/${{ github.event.repository.name }}
+        gsutil -m cp -r ./_docs-prepare gs://prod-econo-cm_docs/${{ github.event.repository.name }}

--- a/upload-docs/action.yml
+++ b/upload-docs/action.yml
@@ -22,20 +22,20 @@ runs:
     - name: Upload docs
       shell: bash
       env:
-        docs_directory_name: ${{ inputs.docs_bucket_sa }}
+        DOCS_DIR: ${{ inputs.docs_directory_name }}
       run: |
-        if [ -z "$docs_directory_name" ]
+        if [ -z "$DOCS_DIR" ]
         then
           upload_dir=./_docs
 
-          echo "Creating a temporary directory for docs content: $docs_directory_name"
+          echo "Creating a temporary directory for docs content: $DOCS_DIR"
           mkdir -p _docs
 
           echo "Searching for readme.md file and coping to temporary directory"
           find -maxdepth 1 -iname readme.md -exec cp {} ./_docs \;
         else
-          echo "Using requested docs directory: $docs_directory_name"
-          upload_dir=$docs_directory_name
+          echo "Using requested docs directory: $DOCS_DIR"
+          upload_dir=$DOCS_DIR
         fi
 
         echo "Listing docs directory content"


### PR DESCRIPTION
In this PR we are adding custom docs directory support for `upload-docs` action by adding an optinonal `docs_directory_name` input parameter.

By default, if `docs_directory_name` is not supplied, a `README.md` file located in the root directory of the repo will be uploaded.

The change is backwards compatible and does not break the existing setups.